### PR TITLE
Add export and import commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,16 @@ aka add ll "ls -la"
 ```bash
 aka list
 ```
+
+### Export aliases
+
+```bash
+aka export aliases.json
+```
+
+### Import aliases
+
+```bash
+aka import aliases.json
+```
+

--- a/src/cmd/export.go
+++ b/src/cmd/export.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var exportCmd = &cobra.Command{
+	Use:   "export [file]",
+	Short: "Export aliases to a file or stdout",
+	Run: func(cmd *cobra.Command, args []string) {
+		akaDir := getAkaDir()
+		out := ""
+		if len(args) > 0 {
+			out = args[0]
+		}
+		if err := exportAliases(akaDir, out); err != nil {
+			fmt.Fprintln(os.Stderr, "Error exporting aliases:", err)
+			os.Exit(1)
+		}
+	},
+}

--- a/src/cmd/import.go
+++ b/src/cmd/import.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var importCmd = &cobra.Command{
+	Use:   "import [file]",
+	Short: "Import aliases from a file",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		akaDir := getAkaDir()
+		if err := importAliases(akaDir, args[0]); err != nil {
+			fmt.Fprintln(os.Stderr, "Error importing aliases:", err)
+			os.Exit(1)
+		}
+	},
+}

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -11,6 +11,8 @@ var rootCmd = &cobra.Command{
 func Execute() {
 	rootCmd.AddCommand(addCmd)
 	rootCmd.AddCommand(listCmd)
+	rootCmd.AddCommand(exportCmd)
+	rootCmd.AddCommand(importCmd)
 	rootCmd.AddCommand(applyCmd)
 	rootCmd.AddCommand(versionCmd)
 	cobra.CheckErr(rootCmd.Execute())


### PR DESCRIPTION
## Summary
- implement `export` and `import` commands in the Go CLI
- support JSON-based alias backup/restore
- document new commands in README

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68406c51b2ac8332b0f3d5dba30403a0