### PR TITLE
Add JSON export/import commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ To install `aka`, run the following command:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/fdorantesm/aka/refs/heads/main/install.sh | bash
+```
 
 ## Usage
 
@@ -27,4 +28,16 @@ aka add ll "ls -la"
 
 ```bash
 aka list
+```
+
+### Export aliases
+
+```bash
+aka export aliases.json
+```
+
+### Import aliases
+
+```bash
+aka import aliases.json
 ```

--- a/src/cmd/export.go
+++ b/src/cmd/export.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var exportCmd = &cobra.Command{
+	Use:   "export [file]",
+	Short: "Export aliases to a JSON file",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		akaDir := getAkaDir()
+		aliases := make(map[string]string)
+		entries, err := os.ReadDir(akaDir)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Error reading aliases:", err)
+			os.Exit(1)
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".alias") {
+				aliasName := strings.TrimSuffix(entry.Name(), ".alias")
+				content, err := os.ReadFile(filepath.Join(akaDir, entry.Name()))
+				if err != nil {
+					fmt.Fprintln(os.Stderr, "Error reading alias:", err)
+					os.Exit(1)
+				}
+				aliases[aliasName] = strings.TrimSpace(string(content))
+			}
+		}
+		data, err := json.MarshalIndent(aliases, "", "  ")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Error encoding JSON:", err)
+			os.Exit(1)
+		}
+		if err := os.WriteFile(args[0], data, 0644); err != nil {
+			fmt.Fprintln(os.Stderr, "Error writing file:", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Aliases exported to %s\n", args[0])
+	},
+}

--- a/src/cmd/export.go
+++ b/src/cmd/export.go
@@ -27,7 +27,7 @@ var exportCmd = &cobra.Command{
 				aliasName := strings.TrimSuffix(entry.Name(), ".alias")
 				content, err := os.ReadFile(filepath.Join(akaDir, entry.Name()))
 				if err != nil {
-					fmt.Fprintln(os.Stderr, "Error reading alias:", err)
+					fmt.Fprintf(os.Stderr, "Error reading alias file %s: %v\n", entry.Name(), err)
 					os.Exit(1)
 				}
 				aliases[aliasName] = strings.TrimSpace(string(content))

--- a/src/cmd/import.go
+++ b/src/cmd/import.go
@@ -26,7 +26,7 @@ var importCmd = &cobra.Command{
 		akaDir := getAkaDir()
 		for name, command := range aliases {
 			if err := addAlias(akaDir, name, command); err != nil {
-				fmt.Fprintln(os.Stderr, "Error writing alias:", err)
+				fmt.Fprintf(os.Stderr, "Error writing alias '%s': %v\n", name, err)
 				os.Exit(1)
 			}
 		}

--- a/src/cmd/import.go
+++ b/src/cmd/import.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var importCmd = &cobra.Command{
+	Use:   "import [file]",
+	Short: "Import aliases from a JSON file",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		data, err := os.ReadFile(args[0])
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Error reading file:", err)
+			os.Exit(1)
+		}
+		var aliases map[string]string
+		if err := json.Unmarshal(data, &aliases); err != nil {
+			fmt.Fprintln(os.Stderr, "Error parsing JSON:", err)
+			os.Exit(1)
+		}
+		akaDir := getAkaDir()
+		for name, command := range aliases {
+			if err := addAlias(akaDir, name, command); err != nil {
+				fmt.Fprintln(os.Stderr, "Error writing alias:", err)
+				os.Exit(1)
+			}
+		}
+		fmt.Println("Aliases imported successfully.")
+	},
+}

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -12,6 +12,8 @@ func Execute() {
 	rootCmd.AddCommand(addCmd)
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(applyCmd)
+	rootCmd.AddCommand(exportCmd)
+	rootCmd.AddCommand(importCmd)
 	rootCmd.AddCommand(versionCmd)
 	cobra.CheckErr(rootCmd.Execute())
 }


### PR DESCRIPTION
## Summary
- implement `aka export` to save aliases as JSON
- add `aka import` to restore aliases from JSON
- document export/import usage in README

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bb2261d3908332bc64d8e61d6a95fe