### PR TITLE
Add command to remove aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ aka add ll "ls -la"
 aka list
 ```
 
+### Remove alias
+
+```bash
+aka remove ll
+```
+
 ### Export aliases
 
 ```bash

--- a/src/cmd/aliases.go
+++ b/src/cmd/aliases.go
@@ -29,6 +29,17 @@ func addAlias(akaDir, aliasName, command string) error {
 	return os.WriteFile(filePath, []byte(command+"\n"), 0644)
 }
 
+func removeAlias(akaDir, aliasName string) error {
+	filePath := filepath.Join(akaDir, aliasName+".alias")
+	if _, err := os.Stat(filePath); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("alias '%s' does not exist", aliasName)
+		}
+		return err
+	}
+	return os.Remove(filePath)
+}
+
 func listAliases(akaDir string) error {
 	entries, err := os.ReadDir(akaDir)
 	if err != nil {

--- a/src/cmd/remove.go
+++ b/src/cmd/remove.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var removeCmd = &cobra.Command{
+	Use:   "remove [alias]",
+	Short: "Remove an existing alias",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		akaDir := getAkaDir()
+		aliasName := args[0]
+		if err := removeAlias(akaDir, aliasName); err != nil {
+			fmt.Fprintln(os.Stderr, "Error removing alias:", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Alias '%s' removed successfully.\n", aliasName)
+	},
+}

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -10,6 +10,7 @@ var rootCmd = &cobra.Command{
 
 func Execute() {
 	rootCmd.AddCommand(addCmd)
+	rootCmd.AddCommand(removeCmd)
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(applyCmd)
 	rootCmd.AddCommand(exportCmd)


### PR DESCRIPTION
## Summary
- add a remove command that deletes alias files and reports missing entries
- register the command with the CLI root and expose a helper to delete aliases
- document the new alias removal flow in the README

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d73331ecf483328fa04985df4c487a